### PR TITLE
changed lighting talk demo link to point directly to youtube recording

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ as a rule engine to auto-generate threats and their mitigations. The focus of TD
 and alignment with other development lifecycle tools.
 
 The [documentation](http://docs.threatdragon.org) is a good starting point, and there is also a recording of Mike Goodwin
-in a [lightning demo](https://open-security-summit.org/tracks/threat-modeling/lightning-demo-threat-model-tool-demos/)
+in a [lightning demo](https://youtu.be/n6JGcZGFq5o)
 recorded during the OWASP Open Security Summit in June 2020.
 
 Threat Dragon has a [demonstration page](https://threatdragon.org/login). This is on older version which is due to be


### PR DESCRIPTION
Getting a 404 for the link to open-security-summit.org so I replaced it with the link to the video recording located OWASP's youtube channel. 