### PR TITLE
Removing references to core repo, roadmap cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repo is the source for the OWASP Threat Dragon project web pages at https:/
 For any improvements to these pages please create an issue or open a pull request - we will make sure to respond quickly.
 
 Create issues on this repository **only** for content hosted under this subfolder on the OWASP site itself.
-For issues or suggestions related to Threat Dragon itself, please use the core
-[github](https://github.com/OWASP/threat-dragon-core) repository.
+For issues or suggestions related to Threat Dragon itself, please use the
+[Threat Dragon](https://github.com/OWASP/threat-dragon) repository.
 
 ### Project leaders
 * [Mike Goodwin](mailto:mike.goodwin@owasp.org)

--- a/info.md
+++ b/info.md
@@ -20,7 +20,6 @@
 ### Sources
 * [Threat Dragon web app](https://github.com/OWASP/threat-dragon)
 * [Threat Dragon desktop](https://github.com/OWASP/threat-dragon-desktop)
-* [Threat Dragon common](https://github.com/OWASP/threat-dragon-core)
 
 ### Licensing
 * [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0)

--- a/tab_involvement.md
+++ b/tab_involvement.md
@@ -19,13 +19,13 @@ To help you get started, take a look at the [documentaion area](https://threatdr
 
 If you are still having problems, let us know and we will be pleased to help (mike.goodwin@owasp.org and 
 jon.gadsden@owasp.org). All feedback is very welcome, so either email us or add an issue on the
-[GitHub repo](https://github.com/OWASP/threat-dragon-core/issues).
+[GitHub repo](https://github.com/OWASP/threat-dragon/issues).
 
 #### Coding
 Coding help of any kind is always welcome. The project builds easily (let us know if you have any problems)
 so getting up and running should be simple.  There are some
-[developer notes](https://github.com/OWASP/threat-dragon-core/blob/main/dev-notes.md) in the core
-[threat dragon](https://github.com/OWASP/threat-dragon-core) repo to help get started with this project.
+[developer notes](https://github.com/OWASP/threat-dragon/blob/main/dev-notes.md) in the
+[threat dragon](https://github.com/OWASP/threat-dragon) repo to help get started with this project.
 
 #### Threat rule engine
 If you are not into javascript, you can still help! We want to create a powerful threat generation rule engine

--- a/tab_roadmap.md
+++ b/tab_roadmap.md
@@ -33,14 +33,14 @@ The original roadmap had various milestones, most of which were achieved by late
 - [x]  _done in v1.4.0_  provide a dockerfile for running in docker, similar to [existing TD](https://github.com/OWASP/threat-dragon/blob/main/Dockerfile)
 - [ ]  provide an API for CI/CD pipelines, [see here](https://github.com/bbachi/vuejs-nodejs-example/tree/master/api) for an example
 - [x]  _done in v1.4.0_  static code analysis using [ESLint](https://eslint.org)
-- [ ]  webapp test runner [Karma](http://karma-runner.github.io/6.3/intro/installation.html)
+- [x]  webapp test runner [Karma](http://karma-runner.github.io/6.3/intro/installation.html)
 with [Jasmine](https://jasmine.github.io)
 for [Vue Test Utils](https://vue-test-utils.vuejs.org/installation/#using-other-test-runners)
-- [ ]  webapp unit test framework [Jest](https://jestjs.io/) and spies from [Sinon](http://sinonjs.org/)
-- [ ]  backend unit test framework [MochaJS](https://mochajs.org) and assertions from [supertest](https://github.com/visionmedia/supertest#readme)
-- [ ]  component test [Vue testing library](https://github.com/testing-library/vue-testing-library)
-- [ ]  end-to-end test [nightwatch](https://github.com/nightwatchjs/nightwatch) or [puppeteer](https://github.com/puppeteer/puppeteer)
-- [ ]  set up ZAP to provide security testing on commit, similar to [existing TD](https://github.com/OWASP/threat-dragon/blob/main/.github/workflows/zap_scan.yaml)
+- [x]  _v2 branch_ webapp unit test framework [Jest](https://jestjs.io/)
+- [x]  backend unit test framework [MochaJS](https://mochajs.org) and assertions from [chai](https://github.com/chaijs/chai)
+- [x]  _v2 branch_ component test [Vue testing library](https://github.com/testing-library/vue-testing-library)
+- [x]  _v2 branch_ end-to-end test [cypress](https://github.com/cypress-io/cypress) 
+- [x]  _v2 branch_ set up ZAP to provide security testing on commit, similar to [existing TD](https://github.com/OWASP/threat-dragon/blob/main/.github/workflows/zap_scan.yaml)
 - [ ]  frontend logging using [bunyan](https://github.com/trentm/node-bunyan) and optional logging to the console during development 
 - [x]  _done in v1.4.0_  bundle the application and api for production using [webpack](https://webpack.js.org/)
 - [x]  be strictly open source, avoiding using languages or frameworks maintained outside the open source community


### PR DESCRIPTION
The core repo was [recently migrated[(https://github.com/OWASP/threat-dragon/pull/108) to the main threat-dragon repo.  

The core repo will soon [be put in maintenance mode](https://github.com/OWASP/threat-dragon-core/pull/78).  To avoid confusion in the future, all references to anything that used to be in the core was updated.

I also updated the roadmap for 2.0 while I was in there.