### PR TITLE
Fix typos and FAQ link

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,7 +41,7 @@ Use the [documentation](https://threatdragon.github.io) to get started, along wi
 giving a [lightning demo](https://youtu.be/n6JGcZGFq5o) during the OWASP Open Security Summit in June 2020.
 
 Threat Dragon has a [demonstration page](https://threatdragon.org/login). This is on older version which is due to be
-updated soon, and the notable difference is that we now have a desktop version that can be installed on linux - along
+updated soon, and the notable difference is that we now have a desktop version that can be installed on Linux - along
 with Windows and MacOS.
 
 ### Related Projects
@@ -59,5 +59,5 @@ Everyone is welcome and encouraged to participate in our [Projects](/projects), 
 [Events](/events), [Online Groups](https://groups.google.com/a/owasp.com/){:target='_blank'},
 and [Community Slack Channel](https://owasp.slack.com/){:target='_blank'}. We especially encourage diversity
 in all our initiatives. OWASP is a fantastic place to learn about application security, to network, and even
-to build your reputation as an expert. We also encourage you to be [become a member](/membership) or consider
+to build your reputation as an expert. We also encourage you to [become a member](/membership) or consider
 a [donation](/donate) to support our ongoing work.

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ tags: threatdragon
 project: true
 level: 2
 type: tool
-pitch: OWASP Threat Dragon provides a threat modelling application for teams implementing the STRIDE approach, either as a desktop or as a web application. Great for both developers and defenders alike
+pitch: OWASP Threat Dragon provides a threat modeling application for teams implementing the STRIDE approach, either as a desktop or as a web application. Great for both developers and defenders alike
 
 ---
 
@@ -34,7 +34,7 @@ Threat Dragon follows the values and principles of the [threat modeling manifest
 It can be used to record possible threats and decide on their mitigations, as well as giving a visual indication
 of the threat model components and threat surfaces. Threat Dragon runs either as a web application or a desktop application.
 
-Threat Dragon supports STRIDE / LINDDUN / CIA, provides modelling diagrams and implements a rule engine to auto-generate
+Threat Dragon supports STRIDE / LINDDUN / CIA, provides modeling diagrams and implements a rule engine to auto-generate
 threats and their mitigations.
 
 Use the [documentation](https://threatdragon.github.io) to get started, along with the recording of Mike Goodwin

--- a/tab_description.md
+++ b/tab_description.md
@@ -6,13 +6,13 @@ order: 1
 tags: threatdragon
 ---
 
-Threat modelling is widely regarded as a powerful way to build security into the design of applications early in a secure development lifecycle.
-At its best, it is especially good for
+Threat modeling is widely regarded as a powerful way to build security into the design of applications early in a secure development lifecycle.
+At its best, it is especially good for:
 * Ensuring defence-in-depth
 * Establishing consistent security design patterns across an application
 * Flushing out security requirements and user stories
 
-OWASP Threat Dragon provides a free, open-source, threat modelling application for teams implementing the STRIDE approach.
+OWASP Threat Dragon provides a free, open-source, threat modeling application for teams implementing the STRIDE approach.
 It can also be used for categorising threats using LINDDUN and CIA.
 The key areas of focus for the tool is:
 * Great UX - using Threat Dragon should be simple, engaging and fun

--- a/tab_faqs.md
+++ b/tab_faqs.md
@@ -11,7 +11,7 @@ tags: threatdragon
 * [What browsers can be used for Threat Dragon?](https://github.com/OWASP/threat-dragon/wiki/FAQs#what-browsers-can-be-used-for-threat-dragon)
 
 
-* [Hold on...isn't this the same as Mozilla's](https://github.com/OWASP/threat-dragon/wiki/FAQs#what-browsers-can-be-used-for-threat-dragon) [SeaSponge](https://github.com/mozilla/seasponge/blob/master/README.md)?
+* [Hold on...isn't this the same as Mozilla's](https://github.com/OWASP/threat-dragon/wiki/FAQs#hold-onisnt-this-the-same-as-mozillas-seasponge) [SeaSponge](https://github.com/mozilla/seasponge/blob/master/README.md)?
 
 
 * [Why do the earlier releases come from Mike Goodwin's repo, not the OWASP repo?](https://github.com/OWASP/threat-dragon-desktop/wiki/FAQs#why-do-the-earlier-releases-come-from-mike-goodwins-repo-not-the-owasp-repo)

--- a/tab_involvement.md
+++ b/tab_involvement.md
@@ -15,7 +15,7 @@ on the [web application github](https://github.com/OWASP/threat-dragon/releases)
 The desktop variant has installers for Linux, Windows and MacOS which be downloaded from the
 [desktop project github](https://github.com/OWASP/threat-dragon-desktop/releases).
 
-To help you get started, take a look at the [documentaion area](https://threatdragon.github.io).
+To help you get started, take a look at the [documentation area](https://threatdragon.github.io).
 
 If you are still having problems, let us know and we will be pleased to help (mike.goodwin@owasp.org and 
 jon.gadsden@owasp.org). All feedback is very welcome, so either email us or add an issue on the

--- a/tab_roadmap.md
+++ b/tab_roadmap.md
@@ -57,7 +57,7 @@ for [Vue Test Utils](https://vue-test-utils.vuejs.org/installation/#using-other-
 - [x] bundle the application and api for production using [webpack](https://webpack.js.org/)
 - [x] be strictly open source, avoiding using languages or frameworks maintained outside the open source community
 
-**documention**:
+**documentation**:
 - [x] documentation should be updated at the [threat dragon github pages](https://threatdragon.github.io/docs)
 - [x] version 1.x docs are preserved and migrated to version 2.0
 - [x] docs should be static pages based on [Jekyll](https://jekyllrb.com) and [markdown](https://docs.github.com/en/github/working-with-github-pages/setting-up-a-github-pages-site-with-jekyll)


### PR DESCRIPTION
A few minor typo fixes, update an FAQ link and update spelling of 'modelling'/'modeling' to 'modeling' (US spelling) for consistency across the pages.