### PR TITLE
update link to dockerhub to show releases

### DIFF
--- a/info.md
+++ b/info.md
@@ -13,7 +13,7 @@
 
 ### Downloads
 * Single page [web application](https://github.com/OWASP/threat-dragon/releases)
-* Docker [image](https://hub.docker.com/r/threatdragon/owasp-threat-dragon/tags?page=1&ordering=last_updated)
+* Docker [image](https://hub.docker.com/r/threatdragon/owasp-threat-dragon/tags?page=1&ordering=name)
 * Desktop installers for:
 * [Linux / MacOS / Windows](https://github.com/OWASP/threat-dragon/releases)
 


### PR DESCRIPTION
Link to dockerhub is now in reverse alphabetical order, which shows the released versions first