### PR TITLE
Add security disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+## Security Policy
+
+It is not impossible that a malicious actor could somehow embed malware in the markdown or subvert the scripts for this project. 
+If you find anything suspicious in this Threat Dragon site then please let us know ASAP and we will fix it as a priority.
+
+Ideally open a [security advisory][advisory] and this will be provided only to the project's admins in strict confidence.
+
+Alternatively send an encrypted email to [Jon Gadsden][mail] to start the secure disclosure process.
+
+[advisory]: https://github.com/OWASP/www-project-threat-dragon/security/advisories/new
+[mail]: https://flowcrypt.com/me/jongadsden


### PR DESCRIPTION
This adds a security policy which includes a link to the github security advisory process