### PR TITLE
Update on index.md to fix formatting on documentation link

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ of the threat model components and threat surfaces. Threat Dragon runs either as
 Threat Dragon supports STRIDE / [LINDDUN](https://www.linddun.org/) / CIA,
 provides modeling diagrams and implements a rule engine to auto-generate threats and their mitigations.
 
-Use the [https://owasp.org/www-project-threat-dragon/docs-1/) to get started, along with the recording of Mike Goodwin
+Use the [documentation](https://owasp.org/www-project-threat-dragon/docs-1/) to get started, along with the recording of Mike Goodwin
 giving a [lightning demo](https://youtu.be/n6JGcZGFq5o) during the OWASP Open Security Summit in June 2020.
 
 An [introduction](https://www.youtube.com/watch?v=hUOAoc6QGJo) to Threat Dragon is provided by


### PR DESCRIPTION
From [this commit](https://github.com/OWASP/www-project-threat-dragon/commit/31f556bc130df0f1ed779205980f2d2302fb7228) it looks like the updated formatting of the documentation link was missing the link text. This PR just re-adds that link text while keeping the updated documentation link on index.md.