### PR TITLE
Included the recently added DIE and PLOT4ai

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -156,6 +156,7 @@ ini
 Jira
 Libre
 LINDDUN
+PLOT4ai
 Linkability
 mitigations
 OpenDocument

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -157,6 +157,7 @@ Jira
 Libre
 LINDDUN
 PLOT4ai
+ai
 Linkability
 mitigations
 OpenDocument

--- a/docs-2/usage/about.md
+++ b/docs-2/usage/about.md
@@ -15,8 +15,8 @@ permalink: /docs-2/about/
 [Threat Dragon](http://owasp.org/www-project-threat-dragon) is a free, open-source,
 cross-platform [threat modeling](https://owasp.org/www-community/Threat_Modeling)
 application including system diagramming and a rule engine to auto-generate threats/mitigations.
-Threat Dragon supports STRIDE<sup>[1](#footnote1)</sup>, LINDDUN<sup>[2](#footnote2)</sup>
-and CIA<sup>[3](#footnote3)</sup>.
+Threat Dragon supports STRIDE<sup>[1](#footnote1)</sup>, LINDDUN<sup>[2](#footnote2)</sup>,
+CIA<sup>[3](#footnote3)</sup>, DIE<sup>[4](#footnote4)</sup> and PLOT4ai<sup>[5](#footnote5)</sup>
 
 It is an [OWASP Lab Project](https://owasp.org/projects/)
 and follows the values and principles of the threat modeling [manifesto](https://www.threatmodelingmanifesto.org/).
@@ -71,4 +71,10 @@ ____
 </p>
 <p>
 <sup><a name="footnote3">3</a>: Confidentiality, Integrity, Availability</sup>
+</p>
+<p>
+<sup><a name="footnote4">4</a>: Distributed, Immutable, Ephemeral</sup>
+</p>
+<p>
+<sup><a name="footnote5">5</a>: Privacy Library Of Threats 4 Artificial Intelligence</sup>
 </p>

--- a/docs-2/usage/modeling/threats.md
+++ b/docs-2/usage/modeling/threats.md
@@ -45,16 +45,16 @@ For example an Actor element is more likely to have Spoofing and Repudiation thr
 associated with it, and less likely to be vulnerable to
 Tampering, Information disclosure, Denial of service or Elevation of privileges.
 
-According to the type of diagram (STRIDE, LINDDUN and CIA),
+According to the type of diagram (STRIDE, LINDDUN, CIA, DIE and PLOT4ai),
 Threat Dragon will restrict the threat type according to  the element chosen.
 If you find this too restrictive then change the diagram type to 'Generic'
 and this will allow you to select any threat type for any type of element;
-you can always change the diagram back to STRIDE, LINDDUN or CIA later on.
+you can always change the diagram back to STRIDE, LINDDUN, CIA, DIE or PLOT4ai later on.
 
-## STRIDE, LINDDUN, CIA and Generic
+## STRIDE, LINDDUN, CIA, DIE, PLOT4ai and Generic
 
 The threat model can have different types of threats added to it according to the diagram methodology.
-Currently the supported methodologies are STRIDE, LINDDUN and CIA;
+Currently the supported methodologies are STRIDE, LINDDUN, CIA, DIE and PLOT4ai;
 these are selected as part of the diagram attributes when editing the model.
 A 'Generic' methodology is provided so that you can select any type of threat.
 

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ It can be used to record possible threats and decide on their mitigations, as we
 of the threat model components and threat surfaces.
 Threat Dragon runs either as a web application or as a desktop application.
 
-Threat Dragon supports STRIDE / [LINDDUN](https://www.linddun.org/) / CIA,
+Threat Dragon supports STRIDE / [LINDDUN](https://www.linddun.org/) / CIA / DIE / [PLOT4ai](https://plot4.ai/),
 provides modeling diagrams and implements a rule engine to auto-generate threats and their mitigations.
 
 ### Resources

--- a/tab_description.md
+++ b/tab_description.md
@@ -15,7 +15,7 @@ At its best, threat modeling is especially good for:
 * Flushing out security requirements and user stories
 
 OWASP Threat Dragon provides a free, open-source, threat modeling application that is powerful and easy to use.
-It can be used for categorising threats using STRIDE, [LINDDUN](https://www.linddun.org/) and CIA.
+It can be used for categorising threats using STRIDE, [LINDDUN](https://www.linddun.org/) CIA, DIE and [PLOT4ai](https://plot4.ai/).
 The key areas of focus for the tool is:
 
 * Simplicity - you can install and start using Threat Dragon very quickly

--- a/tab_description.md
+++ b/tab_description.md
@@ -15,7 +15,8 @@ At its best, threat modeling is especially good for:
 * Flushing out security requirements and user stories
 
 OWASP Threat Dragon provides a free, open-source, threat modeling application that is powerful and easy to use.
-It can be used for categorising threats using STRIDE, [LINDDUN](https://www.linddun.org/) CIA, DIE and [PLOT4ai](https://plot4.ai/).
+It can be used for categorising threats using STRIDE, [LINDDUN](https://www.linddun.org/) CIA, DIE and
+[PLOT4ai](https://plot4.ai/).
 The key areas of focus for the tool is:
 
 * Simplicity - you can install and start using Threat Dragon very quickly


### PR DESCRIPTION
**Summary**:
Threat Dragon has recently been extended with two models: DIE & PLOT4ai.
I've made an update to the documentation to reflect that.

**Description for the changelog**:
Included the recently added DIE and PLOT4ai where the different models are mentioned

**Other info**:
