### PR TITLE
Reinstate email addresses for leaders

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,6 +1,6 @@
 ### Classification
 
-* <i class="fas fa-flask" style="color:#FFA500;"></i> Lab Project
+* <i class="fas fa-flask fa-2x" style="color:#f7b73c"></i> Lab Project
 * <i class="fas fa-tools fa-2x" style="color:#233e81;"></i> Tool
 
 ### Audience

--- a/leaders.md
+++ b/leaders.md
@@ -1,7 +1,7 @@
 ### Leaders
 
 * [Mike Goodwin](https://github.com/mike-goodwin)
-* [Jon Gadsden](https://github.com/jgadsden)
+* [Jon Gadsden](mailto:jon.gadsden@owasp.org)
 * [Leo Reading](https://github.com/lreading)
 
 ### Main Contributors

--- a/leaders.md
+++ b/leaders.md
@@ -1,8 +1,8 @@
 ### Leaders
 
-* [Mike Goodwin](https://github.com/mike-goodwin)
+* [Mike Goodwin](mailto:mike.goodwin@owasp.org)
 * [Jon Gadsden](mailto:jon.gadsden@owasp.org)
-* [Leo Reading](https://github.com/lreading)
+* [Leo Reading](mailto:leo.reading@owasp.org)
 
 ### Main Contributors
 


### PR DESCRIPTION
**Summary**:
reverts recent change from email addresses to github profiles
it seemed a good idea at the time but was actually the wrong thing to do

**Description for the changelog**:
reinstate email addresses for leaders

**Other info**:

