### PR TITLE
Tweak ZAP references

### DIFF
--- a/docs-2/trust/dast.md
+++ b/docs-2/trust/dast.md
@@ -14,7 +14,7 @@ permalink: /docs-2/dast/
 
 Dynamic application security testing is the process of testing code that is running to identify
 potential vulnerabilities and misconfigurations.
-This is provided by [OWASP ZAP](https://www.zaproxy.org/docs/docker/about/) and is run as part of every commit.
+This is provided by [ZAP](https://www.zaproxy.org/docs/docker/about/) and is run as part of every commit.
 
 ZAP scan results are attached to the output of an action.
 An ignore-list is maintained as a TSV (tab separated values, careful what editor you use).

--- a/docs-2/trust/dependencies.md
+++ b/docs-2/trust/dependencies.md
@@ -17,7 +17,7 @@ The following controls are in place to assist with dependency management of the 
 - Dependabot alerts
 - `npm` for dependency resolution and auditing
 
-The documentation pages are scanned on every commit using [OWASP ZAP][zap] (Zed Attack Proxy).
+The documentation pages are scanned on every commit using [ZAP][zap] (Zed Attack Proxy).
 
 ## Fixing a vulnerable dependency
 


### PR DESCRIPTION
ZAP left OWASP over a year ago, this just adjusts naming.
