### PR TITLE
Revise list of related projects

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -23,7 +23,7 @@ jobs:
           keep_minimum_runs: 10
 
       - name: Delete unused workflows
-        uses: otto-de/purge-deprecated-workflow-runs@v4.0.3
+        uses: otto-de/purge-deprecated-workflow-runs@v4.0.4
         with:
           token: ${{ github.token }}
 

--- a/index.md
+++ b/index.md
@@ -51,11 +51,12 @@ The easiest way to get in contact with the Threat Dragon community is via the OW
 [#project-threat-dragon](https://owasp.slack.com/messages/CURE8PQ68) project channel,
 you may need to [subscribe](https://owasp.org/slack/invite) first.
 
-### Related Projects
+### Related OWASP projects
 
-* [OWASP pytm (Pythonic Threat Modeling)][pytm]
-* [Threat Modeling OWASP Cheat Sheet][tmcs]
-* [Threagile - Agile Threat Modeling][threagile], an (non-OWASP) open source project
+* [pytm (Pythonic Threat Modeling)][pytm]
+* [Threat Modeling Cheat Sheet][tmcs]
+* [Threat Modeling Project][tmproject]
+* [Threat Model Library][tm-library]
 
 ----
 
@@ -66,5 +67,6 @@ Threat Dragon: _making threat modeling less threatening_
 [docs-2]: https://www.threatdragon.com/docs/
 [manifesto]: https://www.threatmodelingmanifesto.org/
 [pytm]: https://owasp.org/www-project-pytm/
-[threagile]: https://threagile.io
 [tmcs]: https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html
+[tmproject]: https://owasp.org/www-project-threat-modeling/
+[tm-library]: https://github.com/OWASP/www-project-threat-model-library

--- a/info.md
+++ b/info.md
@@ -16,10 +16,10 @@
 
 ### Downloads
 
-* Single page [web application](https://github.com/OWASP/threat-dragon/releases/tag/v2.5.0)
+* Single page [web application](https://github.com/OWASP/threat-dragon/releases/latest/)
 * Docker [image](https://hub.docker.com/r/owasp/threat-dragon/tags?page=1&ordering=name)
 * Desktop installers for:
-* [Linux / MacOS / Windows](https://github.com/OWASP/threat-dragon/releases/tag/v2.5.0)
+* [Linux / MacOS / Windows](https://github.com/OWASP/threat-dragon/releases/latest/)
 
 ### Source
 


### PR DESCRIPTION
**Summary**:
The list of related OWASP threat modeling projects needed updating, added 'Threat Modeling Project' and 'Threat Model Library'

**Description for the changelog**:

revise list of related projects

**Other info**:
also removed reference to Threagile as it is still at pre-release version 0.9.x and has not been updated since 2024, so it looks like a stalled / outdated project
